### PR TITLE
Provide custom `Client` implementation to tests

### DIFF
--- a/crates/doco/src/client.rs
+++ b/crates/doco/src/client.rs
@@ -1,0 +1,47 @@
+use fantoccini::error::CmdError;
+use fantoccini::Client as WebDriverClient;
+use reqwest::Url;
+use std::ops::Deref;
+use typed_builder::TypedBuilder;
+
+#[derive(Clone, Debug, TypedBuilder)]
+pub struct Client {
+    base_url: Url,
+    client: WebDriverClient,
+}
+
+impl Client {
+    pub async fn goto(&self, path: &str) -> Result<(), CmdError> {
+        self.client.goto(self.base_url.join(path)?.as_str()).await
+    }
+}
+
+impl Deref for Client {
+    type Target = WebDriverClient;
+
+    fn deref(&self) -> &Self::Target {
+        &self.client
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        assert_send::<Client>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<Client>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<Client>();
+    }
+}

--- a/examples/leptos/e2e/main.rs
+++ b/examples/leptos/e2e/main.rs
@@ -1,15 +1,11 @@
-use doco::server::Server;
-use doco::{Client, Doco, Locator, Result, TestCase};
+use doco::{Client, Doco, Locator, Result, Server, TestCase};
 
 struct Leptos;
 
 impl TestCase for Leptos {
-    async fn execute(&self, client: Client, host: String, port: u16) -> Result<()> {
+    async fn execute(&self, client: Client) -> Result<()> {
         println!("Running end-to-end test...");
-        client
-            .goto(&format!("http://{host}:{port}/"))
-            .await
-            .unwrap();
+        client.goto("/").await?;
 
         let title = client
             .find(Locator::XPath("/html/body/main/h1"))


### PR DESCRIPTION
The `Client` struct from fantoccini[^1] has been "extended" by creating a custom struct that implements `Deref`. This client sets the base URL to the internal IP address and port of the Docker container that runs the server. This cleans up the interface for tests and removes two arguments for test functions.

[^1]: https://crates.io/crates/fantoccini