### PR TITLE
Initialize test runner before executing tests

### DIFF
--- a/examples/leptos/e2e/main.rs
+++ b/examples/leptos/e2e/main.rs
@@ -31,10 +31,7 @@ async fn main() {
 
     let doco = Doco::builder().server(server).build();
 
-    TestRunner::builder()
-        .doco(doco)
-        .build()
-        .run(Leptos)
-        .await
-        .unwrap();
+    let test_runner = TestRunner::init(doco).await.unwrap();
+
+    test_runner.run(Leptos).await.unwrap();
 }


### PR DESCRIPTION
The test runner previously performed the initialization of the test environment as part of the `run` function. This causes a problem when trying to use the runner in the future derive macro, which wraps the test function and runs it in an asynchronous runtime. Since the initialization is asynchronous as well, we would need to wrap that in the runtime as well. With the current design, that would lead to nested `block_on` calls, which would probably create some weird race conditions.

Since the long-term plan is to have more hooks on the test runner (e.g. `before` and `before_each`), it seems reasonable to already split the initialization from the test and avoid the above problem.