### PR TITLE
Wrap test function in a struct

### DIFF
--- a/crates/doco/src/lib.rs
+++ b/crates/doco/src/lib.rs
@@ -9,10 +9,12 @@ use typed_builder::TypedBuilder;
 
 pub use crate::client::Client;
 pub use crate::server::Server;
-pub use crate::test_runner::*;
+pub use crate::test_case::TestCase;
+pub use crate::test_runner::TestRunner;
 
 mod client;
 mod server;
+mod test_case;
 mod test_runner;
 
 #[cfg(test)]

--- a/crates/doco/src/test_case.rs
+++ b/crates/doco/src/test_case.rs
@@ -1,0 +1,37 @@
+use getset::CopyGetters;
+
+use crate::{Client, Result};
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, CopyGetters)]
+pub struct TestCase {
+    #[getset(get_copy = "pub")]
+    function: fn(Client) -> Result<()>,
+}
+
+impl TestCase {
+    pub fn new(function: fn(Client) -> Result<()>) -> Self {
+        Self { function }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[test]
+    fn trait_send() {
+        assert_send::<TestCase>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<TestCase>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<TestCase>();
+    }
+}

--- a/crates/doco/src/test_runner.rs
+++ b/crates/doco/src/test_runner.rs
@@ -5,7 +5,7 @@ use testcontainers::runners::AsyncRunner;
 use testcontainers::{ContainerAsync, GenericImage};
 use tokio::time::sleep;
 
-use crate::{Client, Doco, Result};
+use crate::{Client, Doco, Result, TestCase};
 
 #[derive(Debug)]
 pub struct TestRunner {
@@ -61,7 +61,7 @@ impl TestRunner {
         })
     }
 
-    pub async fn run(&self, test: fn(Client) -> Result<()>) -> Result<()> {
+    pub async fn run(&self, test: TestCase) -> Result<()> {
         for _ in 0..10 {
             if reqwest::Client::new()
                 .get(&self.server_endpoint)
@@ -75,7 +75,7 @@ impl TestRunner {
             }
         }
 
-        test(self.client.clone())?;
+        (test.function())(self.client.clone())?;
 
         Ok(())
     }

--- a/examples/leptos/e2e/main.rs
+++ b/examples/leptos/e2e/main.rs
@@ -1,7 +1,7 @@
 use std::thread;
 
 use anyhow::anyhow;
-use doco::{Client, Doco, Locator, Result, Server, TestRunner};
+use doco::{Client, Doco, Locator, Result, Server, TestCase, TestRunner};
 use tokio::runtime::Builder;
 
 fn has_title(client: Client) -> Result<()> {
@@ -40,6 +40,7 @@ async fn main() {
     let doco = Doco::builder().server(server).build();
 
     let test_runner = TestRunner::init(doco).await.unwrap();
+    let test_case = TestCase::new(has_title);
 
-    test_runner.run(has_title).await.unwrap();
+    test_runner.run(test_case).await.unwrap();
 }


### PR DESCRIPTION
Instead of passing the test function directly to the test runner, it is now wrapped in a `TestCase` struct. This is required by the future derive macro, which uses the inventory[^1] crate to collect all test cases and iterate through them.

[^1]: https://crates.io/crates/inventory