### PR TITLE
Print which test is currently running

### DIFF
--- a/crates/doco/src/test_runner.rs
+++ b/crates/doco/src/test_runner.rs
@@ -17,6 +17,8 @@ pub struct TestRunner {
 
 impl TestRunner {
     pub async fn init(doco: Doco) -> Result<Self> {
+        println!("Initializing ephemeral test environment...");
+
         let selenium = GenericImage::new("selenium/standalone-firefox", "latest")
             .with_exposed_port(4444.tcp())
             .with_wait_for(WaitFor::message_on_stdout("Started Selenium Standalone"))
@@ -61,7 +63,9 @@ impl TestRunner {
         })
     }
 
-    pub async fn run(&self, test: fn(Client) -> Result<()>) -> Result<()> {
+    pub async fn run(&self, name: &str, test: fn(Client) -> Result<()>) -> Result<()> {
+        println!("Running tests...\n");
+
         for _ in 0..10 {
             if reqwest::Client::new()
                 .get(&self.server_endpoint)
@@ -75,7 +79,10 @@ impl TestRunner {
             }
         }
 
+        println!("{}...", name);
         test(self.client.clone())?;
+
+        println!("\nDone.");
 
         Ok(())
     }

--- a/examples/leptos/e2e/main.rs
+++ b/examples/leptos/e2e/main.rs
@@ -2,7 +2,6 @@ use doco::{Client, Doco, Locator, Result, Server};
 
 #[doco::test]
 async fn has_title(client: Client) -> Result<()> {
-    println!("Running end-to-end test...");
     client.goto("/").await?;
 
     let title = client


### PR DESCRIPTION
As a first step towards a better developer experience, Doco now collects and prints the name of the currently running test. Future improvements should include printing the result of the test (`ok` or `failure`), similar to how cargo's test runner does it, and including the module path in the test name so that different modules can have the same name.