### PR TITLE
Add second test case

### DIFF
--- a/crates/doco-derive/src/lib.rs
+++ b/crates/doco-derive/src/lib.rs
@@ -24,11 +24,16 @@ pub fn main(_args: TokenStream, input: TokenStream) -> TokenStream {
             let doco: doco::Doco = #main_block;
 
             let test_runner = doco::TestRunner::init(doco).await.expect("failed to initialize the test runner");
+            let tests = doco::inventory::iter::<TestCase>.into_iter().count();
+
+            println!("Running {} tests...\n", tests);
 
             for test in doco::inventory::iter::<TestCase> {
                 // TODO: Collect results, report them, and remove the `expect` statement
                 test_runner.run(test.name, test.function).await.expect("failed to run test");
             }
+
+            println!("\nDone.");
         }
     };
 

--- a/crates/doco/src/test_runner.rs
+++ b/crates/doco/src/test_runner.rs
@@ -27,8 +27,6 @@ impl TestRunner {
     }
 
     pub async fn run(&self, name: &str, test: fn(Client) -> Result<()>) -> Result<()> {
-        println!("Running tests...\n");
-
         let server = GenericImage::new("doco", "leptos")
             .with_exposed_port(self.doco.server().port().tcp())
             .start()
@@ -74,8 +72,6 @@ impl TestRunner {
 
         println!("{}...", name);
         test(client)?;
-
-        println!("\nDone.");
 
         Ok(())
     }

--- a/examples/leptos/e2e/main.rs
+++ b/examples/leptos/e2e/main.rs
@@ -1,4 +1,7 @@
+use std::time::Duration;
+
 use doco::{Client, Doco, Locator, Result, Server};
+use tokio::time::sleep;
 
 #[doco::test]
 async fn has_title(client: Client) -> Result<()> {
@@ -11,6 +14,28 @@ async fn has_title(client: Client) -> Result<()> {
         .await?;
 
     assert_eq!("Welcome to Leptos!", title);
+
+    Ok(())
+}
+
+#[doco::test]
+async fn clicking_button_increases_counter(client: Client) -> Result<()> {
+    client.goto("/").await?;
+
+    let button = client
+        .find(Locator::XPath("/html/body/main/button"))
+        .await?;
+
+    let before = button.text().await?;
+    assert_eq!("Click Me: 0", before);
+
+    button.click().await?;
+
+    // Wait for the button to update
+    sleep(Duration::from_secs(1)).await;
+
+    let after = button.text().await?;
+    assert_eq!("Click Me: 1", after);
 
     Ok(())
 }


### PR DESCRIPTION
Another test case has been implemented in the Leptos example to ensure that the macros work with multiple tests. Some of the test output has been moved to make sure it is only printed once for the whole test suite and not per test.