### PR TITLE
Remove hard-coded image for the server

### DIFF
--- a/crates/doco/src/test_runner.rs
+++ b/crates/doco/src/test_runner.rs
@@ -27,7 +27,7 @@ impl TestRunner {
     }
 
     pub async fn run(&self, name: &str, test: fn(Client) -> Result<()>) -> Result<()> {
-        let server = GenericImage::new("doco", "leptos")
+        let server = GenericImage::new(self.doco.server().image(), self.doco.server().tag())
             .with_exposed_port(self.doco.server().port().tcp())
             .start()
             .await?;


### PR DESCRIPTION
The image for the server was hard-coded in previous iterations of the test runner, and the image and tag passed to the Doco instance were not being used. This has been fixed so that users can provide their own server images.