### PR TITLE
Write documentation for Rust types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-# 🦕 doco
+# 🦕 Doco
 
-doco is a framework and runner for end-to-end tests of web applications.
+Doco is a framework and runner for end-to-end tests of web applications.
 
 ## License
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE)
+  or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT)
+  or <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/crates/doco/src/client.rs
+++ b/crates/doco/src/client.rs
@@ -1,16 +1,81 @@
+//! WebDriver client that interacts with the web application
+
 use fantoccini::error::CmdError;
 use fantoccini::Client as WebDriverClient;
 use reqwest::Url;
 use std::ops::Deref;
 use typed_builder::TypedBuilder;
 
+/// WebDriver client that interacts with the web application
+///
+/// The `Client` implements the [WebDriver] protocol to interact with the web application. It is
+/// preconfigured to target the server that has been passed to Doco so that users only need to
+/// supply the path that they want to test.
+///
+/// Internally, the client uses the [fantoccini] crate to interact with the WebDriver server. For
+/// examples on what methods are available on the `Client` and how to interact with the web
+/// application, see the [fantoccini] documentation.
+///
+/// # Example
+///
+/// ```rust
+/// use doco::{Client, Result};
+///
+/// #[doco::test]
+/// async fn visit_root_path(client: Client) -> Result<()> {
+///     client.goto("/").await?;
+///
+///     let body = client.source().await?;
+///
+///     assert!(body.contains("Hello World"));
+///
+///     Ok(())
+/// }
+/// #
+/// # use doco::{Doco, Server};
+/// #
+/// # #[doco::main]
+/// # async fn main() -> Doco {
+/// #    let server = Server::builder()
+/// #        .image("crccheck/hello-world")
+/// #        .tag("v1.0.0")
+/// #        .port(8000)
+/// #        .build();
+/// #
+/// #    Doco::builder().server(server).build()
+/// # }
+/// ```
+///
+/// [fantoccini]: https://crates.io/crates/fantoccini
+/// [webdriver]: https://developer.mozilla.org/en-US/docs/Web/WebDriver
 #[derive(Clone, Debug, TypedBuilder)]
 pub struct Client {
+    /// The base URL of the server
     base_url: Url,
+
+    /// The WebDriver client that is used internally
     client: WebDriverClient,
 }
 
 impl Client {
+    /// Navigate to the specified path
+    ///
+    /// This method will navigate to the specified path on the server. The path should be relative
+    /// to the base URL that was passed to Doco.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use doco::{Client, Result};
+    ///
+    /// async fn visit_root_path(client: Client) -> Result<()> {
+    ///     client.goto("/").await?;
+    ///
+    ///     // Interact with the web application and make assertions
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     pub async fn goto(&self, path: &str) -> Result<(), CmdError> {
         self.client.goto(self.base_url.join(path)?.as_str()).await
     }

--- a/crates/doco/src/environment.rs
+++ b/crates/doco/src/environment.rs
@@ -1,18 +1,35 @@
+//! Environment variables for services
+
 use getset::Getters;
 use typed_builder::TypedBuilder;
 
+/// Environment variable for a service
+///
+/// The server and its optional services might require additional configuration to start
+/// successfully. For example, the official Docker image for Postgres requires the
+/// `POSTGRES_PASSWORD` environment variable to be set. This struct represents an environment
+/// variable that can be passed to a service.
+///
+/// Environment variables are in implementation detail of the `doco` crate and are not exposed
+/// publicly. Users can configure them by calling the `env` method on the `ServiceBuilder`. See the
+/// [`Service`] struct for more information.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Getters, TypedBuilder)]
 pub struct Variable {
+    /// The name of the environment variable
     #[builder(setter(into))]
     #[getset(get = "pub")]
     name: String,
 
+    /// The value of the environment variable
     #[builder(setter(into))]
     #[getset(get = "pub")]
     value: String,
 }
 
 impl Variable {
+    /// Create a new environment variable
+    ///
+    /// This function creates a new environment variable with the given name and value.
     pub fn new(name: impl Into<String>, value: impl Into<String>) -> Variable {
         Variable {
             name: name.into(),
@@ -26,6 +43,25 @@ mod tests {
     use crate::test_utils::*;
 
     use super::*;
+
+    #[test]
+    fn from_str() {
+        let variable = Variable::new("name", "value");
+
+        assert_eq!(variable.name(), "name");
+        assert_eq!(variable.value(), "value");
+    }
+
+    #[test]
+    fn from_string() {
+        let name = String::from("name");
+        let value = String::from("value");
+
+        let variable = Variable::new(name, value);
+
+        assert_eq!(variable.name(), "name");
+        assert_eq!(variable.value(), "value");
+    }
 
     #[test]
     fn trait_send() {

--- a/crates/doco/src/lib.rs
+++ b/crates/doco/src/lib.rs
@@ -1,6 +1,48 @@
-//! 🦕 doco
+//! 🦕 Doco
 //!
-//! `doco` is a framework and runner for end-to-tests of web applications.
+//! Doco is a test runner and library for writing end-to-tests of web applications. It is designed
+//! to be framework-agnostic and easy to use, both locally and in CI/CD pipelines.
+//!
+//! Under the hood, Doco uses containers to create ephemeral, isolated environments for each test.
+//! This prevents state to leak between tests and ensures that each test is run with a known and
+//! predictable environment.
+//!
+//! Doco has a very simple, yet powerful API to make it easy to write tests. In a `main` function,
+//! the environment for tests is defined and configured. Most importantly, Doco is told about the
+//! server and its dependencies. Then, tests are written just like with any other Rust test. The
+//! tests are passed a `Client` that can be used to interact with a website, making it easy to
+//! simulate user interactions and write assertions against the web application.
+//!
+//! # Example
+//!
+//! ```rust
+//! use doco::{Client, Doco, Result, Server, Service, WaitFor};
+//!
+//! #[doco::test]
+//! async fn visit_root_path(client: Client) -> Result<()> {
+//!     client.goto("/").await?;
+//!
+//!     let body = client.source().await?;
+//!
+//!     assert!(body.contains("Hello World"));
+//!
+//!     Ok(())
+//! }
+//!
+//! #[doco::main]
+//! async fn main() -> Doco {
+//!     let server = Server::builder()
+//!         .image("crccheck/hello-world")
+//!         .tag("v1.0.0")
+//!         .port(8000)
+//!         .build();
+//!
+//!     Doco::builder().server(server).build()
+//! }
+//! ```
+
+#![warn(missing_docs)]
+#![warn(clippy::missing_docs_in_private_items)]
 
 pub use anyhow::{anyhow, Context, Error, Result};
 pub use doco_derive::{main, test};
@@ -24,11 +66,35 @@ mod test_runner;
 #[cfg(test)]
 mod test_utils;
 
-#[derive(Clone, Debug, Default, Getters, TypedBuilder)]
+/// Configuration for end-to-end tests with Doco
+///
+/// The `Doco` struct configures the environment that is used to run each test, most importantly the
+/// application server and any additional services that it depends on. An instance of this struct
+/// must be returned by the `main` function of the test suite.
+///
+/// # Example
+///
+/// ```rust
+/// use doco::{Doco, Server};
+///
+/// #[doco::main]
+/// async fn main() -> Doco {
+///     let server = Server::builder()
+///         .image("crccheck/hello-world")
+///         .tag("v1.0.0")
+///         .port(8000)
+///         .build();
+///
+///     Doco::builder().server(server).build()
+/// }
+/// ```
+#[derive(Clone, Debug, Getters, TypedBuilder)]
 pub struct Doco {
+    /// The server that Doco will test
     #[getset(get = "pub")]
     server: Server,
 
+    /// Additional services (e.g. databases or caches) that the server depends on
     #[builder(via_mutators(init = Vec::new()), mutators(
         pub fn service(mut self, service: Service) {
             self.services.push(service);
@@ -42,7 +108,24 @@ pub struct Doco {
 mod tests {
     use crate::test_utils::*;
 
-    use super::Doco;
+    use super::{Doco, Server, Service};
+
+    #[test]
+    fn service_collects_services() {
+        let server = Server::builder()
+            .image("crccheck/hello-world")
+            .tag("v1.0.0")
+            .port(8000)
+            .build();
+
+        let doco = Doco::builder()
+            .server(server)
+            .service(Service::builder().image("first").tag("latest").build())
+            .service(Service::builder().image("second").tag("latest").build())
+            .build();
+
+        assert_eq!(doco.services().len(), 2);
+    }
 
     #[test]
     fn trait_send() {

--- a/crates/doco/src/server.rs
+++ b/crates/doco/src/server.rs
@@ -1,18 +1,27 @@
+//! Server for the web application that is being tested
+
 use getset::{CopyGetters, Getters};
 use typed_builder::TypedBuilder;
 
+/// Server for the web application that is being tested
+///
+/// The `Server` struct configures the server that is being tested. Doco runs the server as a Docker
+/// container, using a prebuilt image.
 #[derive(
-    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, CopyGetters, Getters, TypedBuilder,
+    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, CopyGetters, Getters, TypedBuilder,
 )]
 pub struct Server {
+    /// The name of the Docker image for the server, e.g. `rust`
     #[builder(setter(into))]
     #[getset(get = "pub")]
     image: String,
 
+    /// The tag for the Docker image, e.g. `latest`
     #[builder(setter(into))]
     #[getset(get = "pub")]
     tag: String,
 
+    /// The port that the server listens on, e.g. `8080`
     #[getset(get_copy = "pub")]
     port: u16,
 }

--- a/crates/doco/src/service.rs
+++ b/crates/doco/src/service.rs
@@ -1,19 +1,47 @@
+//! Auxiliary service required by the server
+
 use getset::{CopyGetters, Getters};
 use testcontainers::core::WaitFor;
 use typed_builder::TypedBuilder;
 
 use crate::environment::Variable;
 
+/// Auxiliary service required by the server
+///
+/// The [`Server`] might require additional services to work, e.g. a database. These can be
+/// defined using the `Service` struct and added to the [`Doco`] configuration. Each service is run
+/// as a Docker container and can be configured with environment variables.
+///
+/// Services can be accessed from the server by using the `image` name. For example, adding a
+/// `postgres` service will allow the server to connect to `postgres:5432`. See the `axum-postgres`
+/// example in the repository for a working demo.
+///
+/// # Example
+///
+/// ```rust
+/// use doco::Service;
+///
+/// fn postgres() -> Service {
+///     Service::builder()
+///         .image("postgres")
+///         .tag("latest")
+///         .env("POSTGRES_PASSWORD", "password")
+///         .build()
+/// }
+/// ```
 #[derive(Clone, Debug, Default, CopyGetters, Getters, TypedBuilder)]
 pub struct Service {
+    /// The name of the service's Docker image
     #[builder(setter(into))]
     #[getset(get = "pub")]
     image: String,
 
+    /// The tag of the service's Docker image
     #[builder(setter(into))]
     #[getset(get = "pub")]
     tag: String,
 
+    /// Environment variables to set in the service's container
     #[builder(via_mutators(init = Vec::new()), mutators(
         pub fn env(mut self, name: impl Into<String>, value: impl Into<String>) {
             self.envs.push(Variable::new(name, value));
@@ -22,6 +50,7 @@ pub struct Service {
     #[getset(get = "pub")]
     envs: Vec<Variable>,
 
+    /// An optional condition to wait until the service has properly started
     #[builder(default, setter(into))]
     #[getset(get = "pub")]
     wait: Option<WaitFor>,

--- a/crates/doco/src/test_utils.rs
+++ b/crates/doco/src/test_utils.rs
@@ -1,5 +1,10 @@
+//! Utilities for testing this crate
+
+/// Asserts that a type implements `Send`
 pub fn assert_send<T: Send>() {}
 
+/// Asserts that a type implements `Sync`
 pub fn assert_sync<T: Sync>() {}
 
+/// Asserts that a type implements `Unpin`
 pub fn assert_unpin<T: Unpin>() {}


### PR DESCRIPTION
A first pass of documenting the Rust code has been done. All public and private items have at least a comment, with most of them featuring an example.