### PR TITLE
Add optional wait condition to server

### DIFF
--- a/crates/doco-derive/src/lib.rs
+++ b/crates/doco-derive/src/lib.rs
@@ -20,7 +20,7 @@ use syn::{parse_macro_input, ItemFn};
 ///
 /// # Example
 ///
-/// ```no_run
+/// ```ignore
 /// use doco::{Doco, Server};
 ///
 /// #[doco::main]
@@ -80,7 +80,7 @@ pub fn main(_args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// # Example
 ///
-/// ```no_run
+/// ```ignore
 /// use doco::{Client, Result};
 ///
 /// #[doco::test]

--- a/crates/doco/src/server.rs
+++ b/crates/doco/src/server.rs
@@ -1,15 +1,14 @@
 //! Server for the web application that is being tested
 
 use getset::{CopyGetters, Getters};
+use testcontainers::core::WaitFor;
 use typed_builder::TypedBuilder;
 
 /// Server for the web application that is being tested
 ///
 /// The `Server` struct configures the server that is being tested. Doco runs the server as a Docker
 /// container, using a prebuilt image.
-#[derive(
-    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, CopyGetters, Getters, TypedBuilder,
-)]
+#[derive(Clone, Debug, CopyGetters, Getters, TypedBuilder)]
 pub struct Server {
     /// The name of the Docker image for the server, e.g. `rust`
     #[builder(setter(into))]
@@ -24,6 +23,11 @@ pub struct Server {
     /// The port that the server listens on, e.g. `8080`
     #[getset(get_copy = "pub")]
     port: u16,
+
+    /// An optional condition to wait until the server has properly started
+    #[builder(default, setter(into))]
+    #[getset(get = "pub")]
+    wait: Option<WaitFor>,
 }
 
 #[cfg(test)]

--- a/examples/axum-postgres/Dockerfile
+++ b/examples/axum-postgres/Dockerfile
@@ -22,6 +22,10 @@ WORKDIR /app
 # Copy server binary
 COPY --from=builder /app/examples/axum-postgres/target/release/axum-postgres server
 
+# Configure a health check for the server
+HEALTHCHECK CMD curl --fail http://localhost:3000 || exit 1
+
+# Configure the axum server
 ENV RUST_BACKTRACE=full
 EXPOSE 3000
 

--- a/examples/leptos/Dockerfile
+++ b/examples/leptos/Dockerfile
@@ -58,6 +58,9 @@ COPY --from=builder /app/examples/leptos/target/release/leptos-ssr server
 # Copy WASM module, CSS stylesheets, and other static files
 COPY --from=builder /app/examples/leptos/target/leptos site
 
+# Configure a health check for the server
+HEALTHCHECK CMD curl --fail http://localhost:8080 || exit 1
+
 # Configure the Leptos app
 ENV RUST_LOG="info"
 ENV LEPTOS_SITE_ADDR="0.0.0.0:8080"


### PR DESCRIPTION
The server can now be configured with a wait condition that ensures that the server is up and running before executing the tests. This makes it easy to configure a health check for the server and have Doco wait for the server to be fully operational.