### PR TITLE
Add viewport configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to [Semantic
 Versioning].
 
+## [Unreleased]
+
+### Added
+
+- Viewport configuration via `Doco::builder().viewport(Viewport::new(w, h))`.
+  When set, the browser window is resized before each test runs.
+
 ## [0.2.0] - 2026-03-08
 
 ### Changed

--- a/crates/doco/src/lib.rs
+++ b/crates/doco/src/lib.rs
@@ -57,12 +57,14 @@ pub use crate::client::Client;
 pub use crate::server::Server;
 pub use crate::service::Service;
 pub use crate::test_runner::TestRunner;
+pub use crate::viewport::Viewport;
 
 mod client;
 mod environment;
 mod server;
 mod service;
 mod test_runner;
+mod viewport;
 
 #[cfg(test)]
 mod test_utils;
@@ -118,6 +120,14 @@ pub struct Doco {
     ))]
     #[getset(get = "pub")]
     services: Vec<Service>,
+
+    /// The browser viewport dimensions
+    ///
+    /// When set, the browser window is resized to these dimensions before each test runs. This
+    /// ensures consistent rendering for visual regression testing.
+    #[builder(default, setter(strip_option))]
+    #[getset(get = "pub")]
+    viewport: Option<Viewport>,
 }
 
 #[cfg(test)]

--- a/crates/doco/src/test_runner.rs
+++ b/crates/doco/src/test_runner.rs
@@ -130,6 +130,13 @@ impl TestRunner {
         .await
         .expect("failed to connect to WebDriver");
 
+        if let Some(viewport) = self.doco.viewport() {
+            driver
+                .set_window_rect(0, 0, viewport.width(), viewport.height())
+                .await
+                .context("failed to set browser viewport")?;
+        }
+
         let client = Client::builder()
             .base_url(format!("http://{DOCKER_HOST}:{port}").parse()?)
             .client(driver.clone())
@@ -196,6 +203,55 @@ mod tests {
         let body = driver.source().await?;
 
         assert!(body.contains("hello from the test"));
+
+        driver.quit().await.ok();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn viewport_sets_window_dimensions() -> Result<()> {
+        let selenium = start_selenium().await?;
+
+        let driver = thirtyfour::WebDriver::new(
+            &format!(
+                "http://{}:{}",
+                selenium.get_host().await?,
+                selenium.get_host_port_ipv4(4444).await?
+            ),
+            thirtyfour::DesiredCapabilities::firefox(),
+        )
+        .await
+        .expect("failed to connect to WebDriver");
+
+        let viewport = crate::Viewport::new(1280, 720);
+        driver
+            .set_window_rect(0, 0, viewport.width(), viewport.height())
+            .await?;
+
+        let inner_width: u64 = driver
+            .execute("return window.innerWidth", vec![])
+            .await?
+            .json()
+            .as_u64()
+            .unwrap();
+        let inner_height: u64 = driver
+            .execute("return window.innerHeight", vec![])
+            .await?
+            .json()
+            .as_u64()
+            .unwrap();
+
+        // Window chrome takes some space, so innerWidth/innerHeight may differ slightly from the
+        // outer rect. But set_window_rect sets the outer dimensions, so inner dimensions should be
+        // close. The key assertion is that they changed from the default.
+        assert!(inner_width > 0, "innerWidth should be positive");
+        assert!(inner_height > 0, "innerHeight should be positive");
+
+        // The outer rect should match exactly what we requested
+        let rect = driver.get_window_rect().await?;
+        assert_eq!(rect.width, 1280);
+        assert_eq!(rect.height, 720);
 
         driver.quit().await.ok();
 

--- a/crates/doco/src/viewport.rs
+++ b/crates/doco/src/viewport.rs
@@ -1,0 +1,80 @@
+//! Viewport configuration for browser window size
+
+/// Browser viewport dimensions
+///
+/// Controls the browser window size for tests. This is particularly important for visual
+/// regression testing where screenshots must be captured at a consistent size.
+///
+/// # Example
+///
+/// ```rust
+/// use doco::{Doco, Server, Viewport};
+///
+/// # #[doco::main]
+/// # async fn main() -> Doco {
+/// let server = Server::builder()
+///     .image("my-app")
+///     .tag("latest")
+///     .port(8080)
+///     .build();
+///
+/// Doco::builder()
+///     .server(server)
+///     .viewport(Viewport::new(1280, 720))
+///     .build()
+/// # }
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Viewport {
+    /// The width of the browser window in pixels
+    width: u32,
+
+    /// The height of the browser window in pixels
+    height: u32,
+}
+
+impl Viewport {
+    /// Create a new viewport with the given dimensions
+    pub fn new(width: u32, height: u32) -> Self {
+        Self { width, height }
+    }
+
+    /// The width of the browser window in pixels
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// The height of the browser window in pixels
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::*;
+
+    use super::*;
+
+    #[test]
+    fn new_stores_dimensions() {
+        let vp = Viewport::new(1280, 720);
+        assert_eq!(vp.width(), 1280);
+        assert_eq!(vp.height(), 720);
+    }
+
+    #[test]
+    fn trait_send() {
+        assert_send::<Viewport>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        assert_sync::<Viewport>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        assert_unpin::<Viewport>();
+    }
+}


### PR DESCRIPTION
Adds a `Viewport` type and an optional `viewport` field to the `Doco` builder. When set, the browser window is resized to the specified dimensions via `driver.set_window_rect()` before each test runs. This is a prerequisite for Holt's visual regression testing, which needs consistent 1280×720 screenshots across environments.

The field is optional and defaults to `None` (browser default size). Usage:

```rust
Doco::builder()
    .server(server)
    .viewport(Viewport::new(1280, 720))
    .build()
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)