### PR TITLE
Prepare 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning].
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-03-09
+
 ### Added
 
 - Headless browser mode via `Doco::builder().headless(true)`. Defaults to
@@ -41,6 +43,7 @@ Versioning].
 
 Initial release of the `doco` and `doco-derive` crates
 
+[0.2.1]: https://github.com/otterbuild/doco/releases/tag/v0.2.1
 [0.2.0]: https://github.com/otterbuild/doco/releases/tag/v0.2.0
 [0.1.0]: https://github.com/otterbuild/doco/releases/tag/v0.1.0
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "doco"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "doco-derive"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ exclude = ["examples"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/crates/doco/Cargo.toml
+++ b/crates/doco/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../../README.md"
 
 [dependencies]
 anyhow = "1.0.86"
-doco-derive = { path = "../doco-derive", version = "0.2.0" }
+doco-derive = { path = "../doco-derive", version = "0.2.1" }
 thirtyfour = "0.36"
 getset = "0.1.2"
 inventory = "0.3.15"


### PR DESCRIPTION
Bumps workspace version to 0.2.1 and moves the unreleased changelog entries (headless mode, viewport configuration) under the new release date.